### PR TITLE
GenericEntityList の子要素を簡単に検索できるメソッドを生やす

### DIFF
--- a/Assets/Scripts/CAFU/Generics/Data/DataStore/GenericDataStore.cs
+++ b/Assets/Scripts/CAFU/Generics/Data/DataStore/GenericDataStore.cs
@@ -13,7 +13,10 @@ namespace CAFU.Generics.Data.DataStore {
 
     public interface IGenericDataStore : IDataStore {
 
-        TGenericEntity GetEntity<TGenericEntity>(bool checkStrict);
+        TGenericEntity GetEntity<TGenericEntity>() where TGenericEntity : IGenericEntity;
+
+        [Obsolete("Please use overload method has no arguments.")]
+        TGenericEntity GetEntity<TGenericEntity>(bool checkStrict) where TGenericEntity : IGenericEntity;
 
     }
 
@@ -34,17 +37,19 @@ namespace CAFU.Generics.Data.DataStore {
             GenericRepository.GenericDataStore = this;
         }
 
-        public TGenericEntity GetEntity<TGenericEntity>(bool checkStrict) {
+        public TGenericEntity GetEntity<TGenericEntity>() where TGenericEntity : IGenericEntity {
             if (this.GenericEntityList.Any(x => x is TGenericEntity)) {
                 return this.GenericEntityList.OfType<TGenericEntity>().First();
             }
             if (this.ScriptableObjectGenericEntityList.Any(x => x is TGenericEntity)) {
                 return this.ScriptableObjectGenericEntityList.OfType<TGenericEntity>().First();
             }
-            if (checkStrict) {
-                throw new InvalidOperationException(string.Format("Type of '{0}' does not found in GenericDataStore", typeof(TGenericEntity).FullName));
-            }
-            return default(TGenericEntity);
+            throw new InvalidOperationException(string.Format("Type of '{0}' does not found in GenericDataStore", typeof(TGenericEntity).FullName));
+        }
+
+        [Obsolete("Please use overload method has no arguments.")]
+        public TGenericEntity GetEntity<TGenericEntity>(bool checkStrict) where TGenericEntity : IGenericEntity {
+            return this.GetEntity<TGenericEntity>();
         }
 
     }

--- a/Assets/Scripts/CAFU/Generics/Data/Entity/GenericEntity.cs
+++ b/Assets/Scripts/CAFU/Generics/Data/Entity/GenericEntity.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using CAFU.Core.Data.Entity;
 using UnityEngine;
 
 // ReSharper disable ArrangeAccessorOwnerBody
+// ReSharper disable UnusedTypeParameter
 
 #pragma warning disable 649
 
@@ -13,11 +15,43 @@ namespace CAFU.Generics.Data.Entity {
 
     }
 
+    public interface IGenericEntity<out TValue> : IGenericEntity {
+
+        TValue Value { get; }
+
+    }
+
     public interface IGenericPairEntity : IGenericEntity {
 
     }
 
+    public interface IGenericPairEntity<out TKey> : IGenericPairEntity {
+
+        TKey Key { get; }
+
+    }
+
+    public interface IGenericPairEntity<out TKey, out TValue> : IGenericPairEntity<TKey> {
+
+        TValue Value { get; }
+
+    }
+
     public interface IGenericListEntity : IGenericEntity {
+
+    }
+
+    public interface IGenericListEntity<TValue> : IGenericListEntity {
+
+        IList<TValue> List { get; }
+
+    }
+
+    public interface IGenericEntityList<TGenericEntity> : IGenericListEntity<TGenericEntity> where TGenericEntity : IGenericEntity {
+
+    }
+
+    public interface IGenericPairEntityList<TGenericPairEntity> : IGenericEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity {
 
     }
 
@@ -27,7 +61,7 @@ namespace CAFU.Generics.Data.Entity {
 
     }
 
-    public class GenericEntity<TValue> : GenericEntity {
+    public class GenericEntity<TValue> : GenericEntity, IGenericEntity<TValue> {
 
         [SerializeField]
         private TValue value;
@@ -41,7 +75,7 @@ namespace CAFU.Generics.Data.Entity {
     }
 
     // GenericEntity<TValue> を継承する手もあるが、Inspector 上で Key/Value の並びが逆になってしまうので断念
-    public class GenericPairEntity<TKey, TValue> : GenericEntity, IGenericPairEntity {
+    public class GenericPairEntity<TKey, TValue> : GenericEntity, IGenericPairEntity<TKey, TValue> {
 
         [SerializeField]
         private TKey key;
@@ -61,6 +95,11 @@ namespace CAFU.Generics.Data.Entity {
             }
         }
 
+        // ScriptableObjectGenericPairEntity<TKey, TValue>.DummyForAOT() と併せるために書いたが、こっちは要らないはず
+        private void DummyForAOT() {
+            new GenericPairEntityList<ScriptableObjectGenericPairEntity<TKey, TValue>>().GetChildEntity((genericEntity) => true);
+        }
+
     }
 
     public class GenericListEntity<TValue> : GenericEntity, IGenericListEntity {
@@ -72,16 +111,11 @@ namespace CAFU.Generics.Data.Entity {
 
     }
 
-    public class GenericEntityList<TEntity> : GenericListEntity<TEntity> where TEntity : IGenericEntity {
+    public class GenericEntityList<TGenericEntity> : GenericListEntity<TGenericEntity>, IGenericEntityList<TGenericEntity> where TGenericEntity : IGenericEntity {
 
     }
 
     public class GenericPairEntityList<TGenericPairEntity> : GenericEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity {
-
-    }
-
-    [Obsolete("Please use 'GenericPairEntityList<TGenericPairEntity>' instead of thi class.")]
-    public class GenericPairEntityList<TKey, TValue, TGenericPairEntity> : GenericPairEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity {
 
     }
 
@@ -102,7 +136,7 @@ namespace CAFU.Generics.Data.Entity {
     }
 
     // GenericEntity<TValue> を継承する手もあるが、Inspector 上で Key/Value の並びが逆になってしまうので断念
-    public class ScriptableObjectGenericPairEntity<TKey, TValue> : ScriptableObjectGenericEntity, IGenericPairEntity {
+    public class ScriptableObjectGenericPairEntity<TKey, TValue> : ScriptableObjectGenericEntity, IGenericPairEntity<TKey, TValue> {
 
         [SerializeField]
         private TKey key;
@@ -122,6 +156,12 @@ namespace CAFU.Generics.Data.Entity {
             }
         }
 
+        // enum を受け取るメソッドは呼び出しコードが存在しないと AOT コンパイラがコードを生成してくれない
+        // See also: https://docs.unity3d.com/Manual/ScriptingRestrictions.html
+        private void DummyForAOT() {
+            CreateInstance<ScriptableObjectGenericPairEntityList<ScriptableObjectGenericPairEntity<TKey, TValue>>>().GetChildEntity(this.Key);
+        }
+
     }
 
     public class ScriptableObjectGenericListEntity<TValue> : ScriptableObjectGenericEntity, IGenericListEntity {
@@ -133,15 +173,35 @@ namespace CAFU.Generics.Data.Entity {
 
     }
 
-    public class ScriptableObjectGenericEntityList<TEntity> : ScriptableObjectGenericListEntity<TEntity> where TEntity : IGenericEntity {
+    public class ScriptableObjectGenericEntityList<TGenericEntity> : ScriptableObjectGenericListEntity<TGenericEntity>, IGenericEntityList<TGenericEntity> where TGenericEntity : IGenericEntity {
 
     }
 
-    public class ScriptableObjectGenericPairEntityList<TGenericPairEntity> : ScriptableObjectGenericEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity {
+    public class ScriptableObjectGenericPairEntityList<TGenericPairEntity> : ScriptableObjectGenericEntityList<TGenericPairEntity>, IGenericPairEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity {
+
+    }
+
+    // XXX: 拡張メソッドではなく、各クラスに生やす手もある。コードが分散するが AOT 問題が起きる場合は有効かも？有効じゃないかも？
+    public static class GenericEntityExtension {
+
+        public static TGenericEntity GetChildEntity<TGenericEntity>(this IGenericEntityList<TGenericEntity> self, Func<TGenericEntity, bool> predicate)
+            where TGenericEntity : IGenericEntity {
+            return self.List.First(predicate);
+        }
+
+        public static TGenericPairEntity GetChildEntity<TGenericPairEntity, TKey>(this IGenericPairEntityList<TGenericPairEntity> self, TKey key)
+            where TGenericPairEntity : IGenericPairEntity<TKey> {
+            return self.List.First(x => x.Key.Equals(key));
+        }
 
     }
 
     [Obsolete("Please use 'GenericPairEntityList<TGenericPairEntity>' instead of thi class.")]
+    public class GenericPairEntityList<TKey, TValue, TGenericPairEntity> : GenericPairEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity {
+
+    }
+
+    [Obsolete("Please use 'ScriptableObjectGenericPairEntityList<TGenericPairEntity>' instead of thi class.")]
     public class ScriptableObjectGenericPairEntityList<TKey, TValue, TGenericPairEntity> : ScriptableObjectGenericPairEntityList<TGenericPairEntity> where TGenericPairEntity : IGenericPairEntity {
 
     }

--- a/Assets/Scripts/CAFU/Generics/Domain/Repository/GenericRepository.cs
+++ b/Assets/Scripts/CAFU/Generics/Domain/Repository/GenericRepository.cs
@@ -1,4 +1,5 @@
-﻿using CAFU.Core.Domain.Repository;
+﻿using System;
+using CAFU.Core.Domain.Repository;
 using CAFU.Generics.Data.DataStore;
 using CAFU.Generics.Data.Entity;
 
@@ -11,7 +12,10 @@ namespace CAFU.Generics.Domain.Repository {
     public interface IGenericRepository<out TGenericEntity> : IGenericRepository
         where TGenericEntity : IGenericEntity {
 
-        TGenericEntity GetEntity(bool checkStrict = true);
+        TGenericEntity GetEntity();
+
+        [Obsolete("Please use overload method has no arguments.")]
+        TGenericEntity GetEntity(bool checkStrict);
 
     }
 
@@ -28,8 +32,13 @@ namespace CAFU.Generics.Domain.Repository {
 
         }
 
-        public TGenericEntity GetEntity(bool checkStrict = true) {
-            return GenericDataStore.GetEntity<TGenericEntity>(checkStrict);
+        public TGenericEntity GetEntity() {
+            return GenericDataStore.GetEntity<TGenericEntity>();
+        }
+
+        [Obsolete("Please use overload method has no arguments.")]
+        public TGenericEntity GetEntity(bool checkStrict) {
+            return this.GetEntity();
         }
 
     }

--- a/Assets/Scripts/CAFU/Generics/Domain/UseCase/GenericUseCase.cs
+++ b/Assets/Scripts/CAFU/Generics/Domain/UseCase/GenericUseCase.cs
@@ -1,4 +1,5 @@
-﻿using CAFU.Core.Domain.UseCase;
+﻿using System;
+using CAFU.Core.Domain.UseCase;
 using CAFU.Generics.Data.Entity;
 using CAFU.Generics.Domain.Repository;
 
@@ -11,7 +12,10 @@ namespace CAFU.Generics.Domain.UseCase {
     public interface IGenericUseCase<out TGenericEntity> : IGenericUseCase
         where TGenericEntity : IGenericEntity {
 
-        TGenericEntity GetEntity(bool checkStrict = true);
+        TGenericEntity GetEntity();
+
+        [Obsolete("Please use overload method has no arguments.")]
+        TGenericEntity GetEntity(bool checkStrict);
 
     }
 
@@ -29,8 +33,13 @@ namespace CAFU.Generics.Domain.UseCase {
 
         private IGenericRepository<TGenericEntity> GenericRepository { get; set; }
 
-        public TGenericEntity GetEntity(bool checkStrict = true) {
-            return this.GenericRepository.GetEntity(checkStrict);
+        public TGenericEntity GetEntity() {
+            return this.GenericRepository.GetEntity();
+        }
+
+        [Obsolete("Please use overload method has no arguments.")]
+        public TGenericEntity GetEntity(bool checkStrict) {
+            return this.GetEntity();
         }
 
     }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm install github:umm-projects/cafu_generics
   * 紛らわしいが、値の型制約として `IGenericEntity` 型に限定している
 * 定数 Entity の一覧から値を取得するなどの場合に用いる
   * 一応用意しているが、あまり使うコトは無さそう
+* `GetChildEntity(Func<TGenericEntity, bool> predicate)` という子要素を検索するための拡張メソッドも生やしてある
 
 #### `GenericPairEntityList<TGenericPairEntity>`, `ScriptableObjectGenericPairEntityList<TGenericPairEntity>`
 
@@ -51,6 +52,7 @@ npm install github:umm-projects/cafu_generics
   * 紛らわしいが、値の型制約として `IGenericPairEntity` 型に限定している
 * 疑似 Dictionary を作る場合などに用いる
   * 恐らく最も利用する頻度の高い Entity
+* `GetChildEntity(TKey key)` という子要素を検索するための拡張メソッドも生やしてある
 
 ### DataStore
 


### PR DESCRIPTION
* 通常の IGenericEntityList 用に `GetChildEntity(Func<TGenericEntity, bool> predicate)`
* IGenericPairEntityList 用には `GetChildEntity(TKey key)` も