### PR TITLE
Implement GenericEntity Container

### DIFF
--- a/Assets/Scripts/Data/DataStore/GenericEntityContainerDataStore.cs
+++ b/Assets/Scripts/Data/DataStore/GenericEntityContainerDataStore.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CAFU.Core.Data.DataStore;
+using CAFU.Core.Utility;
+using CAFU.Generics.Data.Entity;
+
+namespace CAFU.Generics.Data.DataStore
+{
+    public interface IGenericEntityContainerDataStore : IDataStore
+    {
+        void Retain(IGenericEntity genericEntity);
+
+        void Release(IGenericEntity genericEntity);
+
+        TGenericEntity GetEntity<TGenericEntity>() where TGenericEntity : IGenericEntity;
+
+        IEnumerable<TGenericEntity> GetEntities<TGenericEntity>() where TGenericEntity : IGenericEntity;
+    }
+
+    public class GenericEntityContainerDataStore : IGenericEntityContainerDataStore, ISingleton
+    {
+        public class Factory<TDataStore> : DefaultDataStoreFactory<TDataStore> where TDataStore : IDataStore, IGenericEntityContainerDataStore, new()
+        {
+        }
+
+        public class DefaultResolver : IDataStoreResolver<GenericEntityContainerDataStore>, ISingleton
+        {
+            public GenericEntityContainerDataStore Resolve()
+            {
+                return new Factory<GenericEntityContainerDataStore>().Create();
+            }
+        }
+
+        private Dictionary<IGenericEntity, int> ReferenceCountMap { get; } = new Dictionary<IGenericEntity, int>();
+
+        public void Retain(IGenericEntity genericEntity)
+        {
+            if (!ReferenceCountMap.ContainsKey(genericEntity))
+            {
+                ReferenceCountMap[genericEntity] = 0;
+            }
+
+            ReferenceCountMap[genericEntity]++;
+        }
+
+        public void Release(IGenericEntity genericEntity)
+        {
+            if (!ReferenceCountMap.ContainsKey(genericEntity))
+            {
+                return;
+            }
+
+            ReferenceCountMap[genericEntity]--;
+            if (ReferenceCountMap[genericEntity] <= 0)
+            {
+                ReferenceCountMap.Remove(genericEntity);
+            }
+        }
+
+        public TGenericEntity GetEntity<TGenericEntity>() where TGenericEntity : IGenericEntity
+        {
+            if (!ReferenceCountMap.Keys.Any(x => x is TGenericEntity))
+            {
+                throw new InvalidOperationException($"Type of '{typeof(TGenericEntity).FullName}' does not found in GenericDataStore");
+            }
+
+            return (TGenericEntity) ReferenceCountMap.Keys.First(x => x is TGenericEntity);
+        }
+
+        public IEnumerable<TGenericEntity> GetEntities<TGenericEntity>() where TGenericEntity : IGenericEntity
+        {
+            if (!ReferenceCountMap.Keys.Any(x => x is TGenericEntity))
+            {
+                throw new InvalidOperationException($"Type of '{typeof(TGenericEntity).FullName}' does not found in GenericDataStore");
+            }
+
+            return ReferenceCountMap.Keys.OfType<TGenericEntity>();
+        }
+    }
+}

--- a/Assets/Scripts/Data/DataStore/GenericEntityContainerDataStore.cs
+++ b/Assets/Scripts/Data/DataStore/GenericEntityContainerDataStore.cs
@@ -77,5 +77,10 @@ namespace CAFU.Generics.Data.DataStore
 
             return ReferenceCountMap.Keys.OfType<TGenericEntity>();
         }
+
+        public static GenericEntityContainerDataStore CreateDefaultInstance()
+        {
+            return new DefaultFactory<DefaultResolver>().Create().Resolve();
+        }
     }
 }

--- a/Assets/Scripts/Data/DataStore/GenericEntityContainerDataStore.cs.meta
+++ b/Assets/Scripts/Data/DataStore/GenericEntityContainerDataStore.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fd4370bb6e4c4263af946297c6d151a7
+timeCreated: 1527588025

--- a/Assets/Scripts/Domain/UseCase/GenericUseCase.cs
+++ b/Assets/Scripts/Domain/UseCase/GenericUseCase.cs
@@ -1,4 +1,5 @@
-﻿using CAFU.Core.Domain.UseCase;
+﻿using System.Collections.Generic;
+using CAFU.Core.Domain.UseCase;
 using CAFU.Generics.Data.Entity;
 using CAFU.Generics.Domain.Repository;
 using JetBrains.Annotations;
@@ -15,6 +16,8 @@ namespace CAFU.Generics.Domain.UseCase
         where TGenericEntity : IGenericEntity
     {
         TGenericEntity GetEntity();
+
+        IEnumerable<TGenericEntity> GetEntities();
     }
 
     [PublicAPI]
@@ -35,6 +38,11 @@ namespace CAFU.Generics.Domain.UseCase
         public TGenericEntity GetEntity()
         {
             return GenericRepository.GetEntity();
+        }
+
+        public IEnumerable<TGenericEntity> GetEntities()
+        {
+            return GenericRepository.GetEntities();
         }
     }
 }


### PR DESCRIPTION
* Fixes #14 
* `IGenericEntity` のインスタンスを格納するための Container クラスを実装します
* `GenericDataStore` のインスタンスが初期化されるタイミングで Container に対して `IGenericEntity` のインスタンスを登録します
* 登録済みの場合は参照カウンタをインクリメントし、 `GenericDataStore` のインスタンスが破棄されるタイミングで参照カウンタをデクリメントし、参照カウンタが0になったインスタンスを Container から破棄します
    * インスタンスの Destroy などは行わず、GC に任せる形になります
* `GenericEntityContainerDataStore` 自体を DI 可能にしており、Resolver を差し替えるコトで独自実装することも可能です
    * あまり需要があるかは分かりませんが 😓 
