### PR TITLE
Remove dynamic

### DIFF
--- a/Assets/Scripts/Domain/Model/GenericStateModel.cs
+++ b/Assets/Scripts/Domain/Model/GenericStateModel.cs
@@ -99,11 +99,13 @@ namespace CAFU.Generics.Domain.Model
         public GenericStateModel()
         {
             State = new ReactiveProperty<TState>();
+            Initialize();
         }
 
         public GenericStateModel(TState initialValue)
         {
             State = new ReactiveProperty<TState>(initialValue);
+            Initialize();
         }
 
         private IList<TState> enumValueList;

--- a/Assets/Scripts/Domain/Model/GenericStateModel.cs
+++ b/Assets/Scripts/Domain/Model/GenericStateModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using CAFU.Core.Domain.Model;
 using JetBrains.Annotations;
 using UniRx;
@@ -62,12 +64,36 @@ namespace CAFU.Generics.Domain.Model
 
         public void Next()
         {
-            State.Value = (dynamic) State.Value + 1;
+            var type = typeof(TState);
+            if (type.IsEnum)
+            {
+                var currentIndex = enumValueList.IndexOf(State.Value);
+                if (enumValueList.Count > currentIndex + 1)
+                {
+                    State.Value = enumValueList[currentIndex + 1];
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("Cannot call Next() to non-enum typed GenericStateModel. Because iOS is not allow `dynamic' call.");
+            }
         }
 
         public void Previous()
         {
-            State.Value = (dynamic) State.Value - 1;
+            var type = typeof(TState);
+            if (type.IsEnum)
+            {
+                var currentIndex = enumValueList.IndexOf(State.Value);
+                if (currentIndex > 0)
+                {
+                    State.Value = enumValueList[currentIndex - 1];
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("Cannot call Previous() to non-enum typed GenericStateModel. Because iOS is not allow `dynamic' call.");
+            }
         }
 
         public GenericStateModel()
@@ -78,6 +104,17 @@ namespace CAFU.Generics.Domain.Model
         public GenericStateModel(TState initialValue)
         {
             State = new ReactiveProperty<TState>(initialValue);
+        }
+
+        private IList<TState> enumValueList;
+
+        private void Initialize()
+        {
+            var type = typeof(TState);
+            if (type.IsEnum)
+            {
+                enumValueList = new List<TState>(Enum.GetValues(type).OfType<TState>());
+            }
         }
     }
 }

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 992d239e709c94cd8814cd79d43ed11e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6edfb627626044b869461879dc9c7c2c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Scripts.meta
+++ b/Assets/Tests/EditMode/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27a0627c55e9c408c825d9159a696340
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Scripts/Domain.meta
+++ b/Assets/Tests/EditMode/Scripts/Domain.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d13f7e6b8a44d4a4d949113a274f6dd0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Scripts/Domain/Model.meta
+++ b/Assets/Tests/EditMode/Scripts/Domain/Model.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d07318ab120b411a8835b72f58c8ee8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Scripts/Domain/Model/GenericStateModelTest.cs
+++ b/Assets/Tests/EditMode/Scripts/Domain/Model/GenericStateModelTest.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GenericStateModelTest : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/Assets/Tests/EditMode/Scripts/Domain/Model/GenericStateModelTest.cs
+++ b/Assets/Tests/EditMode/Scripts/Domain/Model/GenericStateModelTest.cs
@@ -1,16 +1,61 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
 
-public class GenericStateModelTest : MonoBehaviour {
+namespace CAFU.Generics.Domain.Model
+{
+    public class GenericStateModelTest
+    {
+        [SuppressMessage("ReSharper", "UnusedMember.Local")]
+        private enum Fixture
+        {
+            Foo,
+            Bar,
+            Baz,
+            Qux,
+        }
 
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
-	}
+        [Test]
+        public void EnumNextTest()
+        {
+            var model = new GenericStateModel<Fixture>();
+            Assert.AreEqual(default(Fixture), model.GetCurrent());
+            model.Next();
+            model.Next();
+            Assert.AreEqual(Fixture.Baz, model.GetCurrent());
+            model.Next();
+            Assert.AreEqual(Fixture.Qux, model.GetCurrent());
+            model.Next();
+            model.Next();
+            Assert.AreEqual(Fixture.Qux, model.GetCurrent());
+        }
+
+        [Test]
+        public void EnumPreviousTest()
+        {
+            var model = new GenericStateModel<Fixture>(Fixture.Qux);
+            Assert.AreEqual(Fixture.Qux, model.GetCurrent());
+            model.Previous();
+            Assert.AreEqual(Fixture.Baz, model.GetCurrent());
+            model.Previous();
+            model.Previous();
+            Assert.AreEqual(Fixture.Foo, model.GetCurrent());
+            model.Previous();
+            model.Previous();
+            Assert.AreEqual(Fixture.Foo, model.GetCurrent());
+        }
+
+        [Test]
+        public void PrimitiveTest()
+        {
+            var model1 = new GenericStateModel<int>();
+            model1.Change(2);
+            Assert.Throws<InvalidOperationException>(() => model1.Next());
+            Assert.Throws<InvalidOperationException>(() => model1.Previous());
+            var model2 = new GenericStateModel<bool>();
+            model2.Change(false);
+            Assert.Throws<InvalidOperationException>(() => model2.Next());
+            Assert.Throws<InvalidOperationException>(() => model2.Previous());
+        }
+    }
 }

--- a/Assets/Tests/EditMode/Scripts/Domain/Model/GenericStateModelTest.cs.meta
+++ b/Assets/Tests/EditMode/Scripts/Domain/Model/GenericStateModelTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 850e5edfa1a1f45cfba9232c200190bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/umm@cafu_generics-Tests-EditMode.asmdef
+++ b/Assets/Tests/EditMode/umm@cafu_generics-Tests-EditMode.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "umm@cafu_generics-Tests-EditMode",
+    "references": [
+        "umm@cafu_generics"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/Assets/Tests/EditMode/umm@cafu_generics-Tests-EditMode.asmdef
+++ b/Assets/Tests/EditMode/umm@cafu_generics-Tests-EditMode.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "umm@cafu_generics-Tests-EditMode",
     "references": [
+        "umm@cafu_core",
         "umm@cafu_generics"
     ],
     "optionalUnityReferences": [

--- a/Assets/Tests/EditMode/umm@cafu_generics-Tests-EditMode.asmdef.meta
+++ b/Assets/Tests/EditMode/umm@cafu_generics-Tests-EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0bf091862ad9a4a6bb82b6fbc595f412
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,4 +1,39 @@
 {
-	"dependencies": {
-	}
+  "dependencies": {
+    "com.unity.ads": "2.0.8",
+    "com.unity.analytics": "2.0.16",
+    "com.unity.package-manager-ui": "1.9.11",
+    "com.unity.purchasing": "2.0.3",
+    "com.unity.textmeshpro": "1.2.4",
+    "com.unity.modules.ai": "1.0.0",
+    "com.unity.modules.animation": "1.0.0",
+    "com.unity.modules.assetbundle": "1.0.0",
+    "com.unity.modules.audio": "1.0.0",
+    "com.unity.modules.cloth": "1.0.0",
+    "com.unity.modules.director": "1.0.0",
+    "com.unity.modules.imageconversion": "1.0.0",
+    "com.unity.modules.imgui": "1.0.0",
+    "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.modules.particlesystem": "1.0.0",
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0",
+    "com.unity.modules.screencapture": "1.0.0",
+    "com.unity.modules.terrain": "1.0.0",
+    "com.unity.modules.terrainphysics": "1.0.0",
+    "com.unity.modules.tilemap": "1.0.0",
+    "com.unity.modules.ui": "1.0.0",
+    "com.unity.modules.uielements": "1.0.0",
+    "com.unity.modules.umbra": "1.0.0",
+    "com.unity.modules.unityanalytics": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0",
+    "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+    "com.unity.modules.unitywebrequestaudio": "1.0.0",
+    "com.unity.modules.unitywebrequesttexture": "1.0.0",
+    "com.unity.modules.unitywebrequestwww": "1.0.0",
+    "com.unity.modules.vehicles": "1.0.0",
+    "com.unity.modules.video": "1.0.0",
+    "com.unity.modules.vr": "1.0.0",
+    "com.unity.modules.wind": "1.0.0",
+    "com.unity.modules.xr": "1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,7 @@
     "@umm/unirx": "umm/unirx#^2.0.0",
     "@umm/unirx_observablelifecyclemonobehaviour": "umm/unirx_observablelifecyclemonobehaviour#^1.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@umm/extra_unirx": "umm/extra_unirx#^1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,5 @@
     "@umm/unirx": "umm/unirx#^2.0.0",
     "@umm/unirx_observablelifecyclemonobehaviour": "umm/unirx_observablelifecyclemonobehaviour#^1.0.0"
   },
-  "devDependencies": {
-    "@umm/extra_unirx": "umm/extra_unirx#^1.0.0"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
# What

* Fixes #17 
* Remove `dynamic` keyword from `GenericStateModel`

# Why

* iOS cannot use `dynamic`
    * See also [this discussion](https://forum.unity.com/threads/il2cpp-error-on-dynamic-keyword.506482/) and [this article](https://www.wintellect.com/cant-use-dynamic-c-keyword-xamarin-ios/)

# Note

* Throw `InvalidOperationException` if use `Next()`, `Previous()` to primitive types